### PR TITLE
Fix dvc

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,6 @@
 [core]
     remote = origin
 ['remote "origin"']
+    url = https://furiosa-public-artifacts.s3.amazonaws.com/furiosa-artifacts
+['remote "s3origin"']
     url = s3://furiosa-public-artifacts/furiosa-artifacts

--- a/artifacts.py
+++ b/artifacts.py
@@ -1,6 +1,7 @@
 import io
 from typing import Any
 
+import aiohttp
 import dvc.api
 from furiosa.registry import Format, Metadata, Model, Publication
 
@@ -17,15 +18,17 @@ from furiosa.artifacts.vision.models.object_detection import (
 )
 
 
-def load_dvc(uri: str, *args, mode="rb", **kwargs):
-    return dvc.api.read(uri, *args, mode=mode, **kwargs)
+async def load_dvc(uri: str):
+    async with aiohttp.ClientSession() as session:
+        async with session.get(dvc.api.get_url(uri)) as resp:
+            return await resp.read()
 
 
 # Image classification
 async def MLCommonsResNet50(*args: Any, **kwargs: Any) -> MLCommonsResNet50Model:
     return MLCommonsResNet50Model(
         name="MLCommonsResNet50",
-        model=load_dvc("models/mlcommons_resnet50_v1.5_int8.onnx"),
+        model=await load_dvc("models/mlcommons_resnet50_v1.5_int8.onnx"),
         format=Format.ONNX,
         family="ResNet",
         version="v1.5",
@@ -73,7 +76,7 @@ async def EfficientNetV2_M(*args: Any, **kwargs: Any) -> Model:
 async def MLCommonsSSDMobileNet(*args: Any, **kwargs: Any) -> MLCommonsSSDSmallModel:
     return MLCommonsSSDSmallModel(
         name="MLCommonsSSDMobileNet",
-        model=load_dvc("models/mlcommons_ssd_mobilenet_v1_int8.onnx.dvc"),
+        model=await load_dvc("models/mlcommons_ssd_mobilenet_v1_int8.onnx"),
         format=Format.ONNX,
         family="MobileNetV1",
         version="v1.1",
@@ -88,7 +91,7 @@ async def MLCommonsSSDMobileNet(*args: Any, **kwargs: Any) -> MLCommonsSSDSmallM
 async def MLCommonsSSDResNet34(*args: Any, **kwargs: Any) -> MLCommonsSSDLargeModel:
     return MLCommonsSSDLargeModel(
         name="MLCommonsSSDResNet34",
-        model=load_dvc("models/mlcommons_ssd_resnet34_int8.onnx.dvc"),
+        model=await load_dvc("models/mlcommons_ssd_resnet34_int8.onnx"),
         format=Format.ONNX,
         family="ResNet",
         version="v1.1",

--- a/artifacts.py
+++ b/artifacts.py
@@ -3,7 +3,6 @@ from typing import Any
 
 import dvc.api
 from furiosa.registry import Format, Metadata, Model, Publication
-from furiosa.registry.client.transport import FileTransport
 
 from furiosa.artifacts.vision.models.image_classification import (
     EfficientNetV2_M as EfficientNetV2_MModel,
@@ -17,15 +16,16 @@ from furiosa.artifacts.vision.models.object_detection import (
     MLCommonsSSDSmallModel,
 )
 
-def load_dvc(uri: str, mode: str = "r"):
-    return dvc.api.read(uri, mode=mode)
+
+def load_dvc(uri: str, *args, mode="rb", **kwargs):
+    return dvc.api.read(uri, *args, mode=mode, **kwargs)
 
 
 # Image classification
 async def MLCommonsResNet50(*args: Any, **kwargs: Any) -> MLCommonsResNet50Model:
     return MLCommonsResNet50Model(
         name="MLCommonsResNet50",
-        model=load_dvc("models/mlcommons_resnet50_v1.5_int8.onnx.dvc"),
+        model=load_dvc("models/mlcommons_resnet50_v1.5_int8.onnx"),
         format=Format.ONNX,
         family="ResNet",
         version="v1.5",

--- a/artifacts.py
+++ b/artifacts.py
@@ -36,6 +36,7 @@ async def MLCommonsResNet50(*args: Any, **kwargs: Any) -> MLCommonsResNet50Model
             description="ResNet50 v1.5 int8 ImageNet-1K Accuracy 75.982% @ Top1",
             publication=Publication(url="https://arxiv.org/abs/1512.03385.pdf"),
         ),
+        *args,
         **kwargs,
     )
 
@@ -51,6 +52,7 @@ async def EfficientNetV2_S(*args: Any, **kwargs: Any) -> Model:
             description="EfficientNetV2 from Google AutoML",
             publication=Publication(url="https://arxiv.org/abs/2104.00298"),
         ),
+        *args,
         **kwargs,
     )
 
@@ -66,6 +68,7 @@ async def EfficientNetV2_M(*args: Any, **kwargs: Any) -> Model:
             description="EfficientNetV2 from Google AutoML",
             publication=Publication(url="https://arxiv.org/abs/2104.00298"),
         ),
+        *args,
         **kwargs,
     )
 
@@ -84,6 +87,7 @@ async def MLCommonsSSDMobileNet(*args: Any, **kwargs: Any) -> MLCommonsSSDSmallM
             description="MobileNet v1 model for MLCommons v1.1",
             publication=Publication(url="https://arxiv.org/abs/1704.04861.pdf"),
         ),
+        *args,
         **kwargs,
     )
 
@@ -101,5 +105,6 @@ async def MLCommonsSSDResNet34(*args: Any, **kwargs: Any) -> MLCommonsSSDLargeMo
                 url="https://github.com/mlcommons/inference/tree/master/vision/classification_and_detection"  # noqa: E501
             ),
         ),
+        *args,
         **kwargs,
     )

--- a/furiosa/artifacts/vision/models/image_classification.py
+++ b/furiosa/artifacts/vision/models/image_classification.py
@@ -3,6 +3,8 @@ from typing import Any, Callable, List, Optional
 import cv2
 import numpy as np
 import timm
+from pydantic import Field
+
 from furiosa.registry import Model
 
 from .common.base import ImageNetRwightman
@@ -86,7 +88,7 @@ class EfficientNetV2_M(EfficientNetV2_S):
 class MLCommonsResNet50Model(Model):
     """MLCommons ResNet50 model"""
 
-    idx2str: List[str] = imagenet1k.ImageNet1k_Idx2Str
+    idx2str: List[str] = Field(imagenet1k.ImageNet1k_Idx2Str, repr=False)
 
     def center_crop(
         self, image: np.ndarray, cropped_height: int, cropped_width: int

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "torch",
     "torchvision",
     "dvc[s3]",
+    "pydantic",
     # Protobuf major version change issue: https://github.com/furiosa-ai/furiosa-artifacts/issues/23
     "protobuf < 4.0dev",
     # segmentation_models_pytorch: from https://github.com/qubvel/segmentation_models.pytorch

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,20 +1,37 @@
 import artifacts
 import pytest
+import yaml
+
+
+def sanity_check_for_dvc_file(model, dvc_file_path: str):
+    assert model
+    assert yaml.safe_load(open(dvc_file_path).read())["outs"][0]["size"] == len(
+        model.model
+    )
 
 
 @pytest.mark.asyncio
 async def test_mlcommons_resnet50():
-    assert await artifacts.MLCommonsResNet50()
+    sanity_check_for_dvc_file(
+        await artifacts.MLCommonsResNet50(),
+        "models/mlcommons_resnet50_v1.5_int8.onnx.dvc",
+    )
 
 
 @pytest.mark.asyncio
 async def test_mlcommons_ssd_mobilenet():
-    assert await artifacts.MLCommonsSSDMobileNet()
+    sanity_check_for_dvc_file(
+        await artifacts.MLCommonsSSDMobileNet(),
+        "models/mlcommons_ssd_mobilenet_v1_int8.onnx.dvc",
+    )
 
 
 @pytest.mark.asyncio
 async def test_mlcommons_ssd_resnet34():
-    assert await artifacts.MLCommonsSSDResNet34()
+    sanity_check_for_dvc_file(
+        await artifacts.MLCommonsSSDResNet34(),
+        "models/mlcommons_ssd_resnet34_int8.onnx.dvc",
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
현재 dvc로 관리되는 실제 파일 대신 dvc metadata파일(*.dvc)을 serving하는 에러가 있습니다.
그리고 public s3 bucket도 파일을 다운로드 받기 위해서는 기본 credential을 필요로 하는데 이를 우회하기 위해
`https://<bucket>.s3.amazonaws.com/<path>` 를 대신 기본 remote로 지정합니다. 필요한 경우 `dvc -r s3origin ~~~` 를 통해 원래 remote를 사용할 수 있습니다.
또 dvc로 관리되는 파일이 잘 serving되고 있는지 테스트를 추가합니다.